### PR TITLE
Aligns SDK endpoints with Vandoor telemetry architecture

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+layout python python3.12
+dotenv_if_exists

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ share/python-wheels/
 *.egg
 MANIFEST
 
-# Virtual environments
+# Virtual environments 
 .env
 .venv
 env/
@@ -31,6 +31,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.direnv
 
 # IDE
 .vscode/

--- a/examples/async_example.py
+++ b/examples/async_example.py
@@ -5,7 +5,7 @@ Asynchronous example of using the Replicated Python SDK.
 
 import asyncio
 
-from replicated import AsyncReplicatedClient, InstanceStatus
+from replicated import AsyncReplicatedClient
 
 
 async def main():
@@ -30,13 +30,6 @@ async def main():
             instance.send_metric("disk_usage", 0.45),
         )
         print("Metrics sent successfully")
-
-        # Set the instance status and version concurrently
-        await asyncio.gather(
-            instance.set_status(InstanceStatus.RUNNING),
-            instance.set_version("1.2.0"),
-        )
-        print("Instance status set to RUNNING and version set to 1.2.0")
 
         print("Example completed successfully!")
 

--- a/examples/metrics_example.py
+++ b/examples/metrics_example.py
@@ -32,6 +32,12 @@ async def main():
     )
     parser.add_argument("--channel", help="Channel for the customer (optional)")
     parser.add_argument("--customer-name", help="Customer name (optional)")
+    parser.add_argument(
+        "--status",
+        choices=["missing", "unavailable", "ready", "updating", "degraded"],
+        default="ready",
+        help="Instance status (default: ready)",
+    )
 
     args = parser.parse_args()
 
@@ -69,6 +75,10 @@ async def main():
         # Get or create the associated instance
         instance = await customer.get_or_create_instance()
         print(f"Instance ID: {instance.instance_id}")
+
+        # Set instance status
+        await instance.set_status(args.status)
+        print(f"✓ Instance status set to: {args.status}")
 
         # Send some metrics concurrently
         await asyncio.gather(

--- a/examples/metrics_example.py
+++ b/examples/metrics_example.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+Basic example of using the Replicated Python SDK.
+This script initializes the replicated package, creates a customer and instance.
+"""
+
+import argparse
+import asyncio
+
+from replicated import AsyncReplicatedClient
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Basic Replicated SDK example")
+    parser.add_argument(
+        "--base-url",
+        default="https://replicated.app",
+        help="Base URL for the Replicated API (default: https://replicated.app)",
+    )
+    parser.add_argument(
+        "--publishable-key",
+        required=True,
+        help="Your Replicated publishable key (required)",
+    )
+    parser.add_argument(
+        "--app-slug", required=True, help="Your application slug (required)"
+    )
+    parser.add_argument(
+        "--customer-email",
+        default="user@example.com",
+        help="Customer email address (default: user@example.com)",
+    )
+    parser.add_argument("--channel", help="Channel for the customer (optional)")
+    parser.add_argument("--customer-name", help="Customer name (optional)")
+
+    args = parser.parse_args()
+
+    print("Initializing Replicated client...")
+    print(f"Base URL: {args.base_url}")
+    print(f"App Slug: {args.app_slug}")
+
+    # Initialize the client
+    async with AsyncReplicatedClient(
+        publishable_key=args.publishable_key,
+        app_slug=args.app_slug,
+        base_url=args.base_url,
+    ) as client:
+        print("✓ Replicated client initialized successfully")
+
+        # Create or get customer
+        channel_info = f" (channel: {args.channel})" if args.channel else ""
+        name_info = f" (name: {args.customer_name})" if args.customer_name else ""
+        print(
+            f"\nCreating/getting customer with email: "
+            f"{args.customer_email}{channel_info}{name_info}"
+        )
+        customer = await client.customer.get_or_create(
+            email_address=args.customer_email,
+            channel=args.channel,
+            name=args.customer_name,
+        )
+        print(f"✓ Customer created/retrieved - ID: {customer.customer_id}")
+
+        # Get or create the associated instance
+        instance = await customer.get_or_create_instance()
+        print(f"Instance ID: {instance.instance_id}")
+        print(f"✓ Instance created/retrieved - ID: {instance.instance_id}")
+
+        # Get or create the associated instance
+        instance = await customer.get_or_create_instance()
+        print(f"Instance ID: {instance.instance_id}")
+
+        # Send some metrics concurrently
+        await asyncio.gather(
+            instance.send_metric("cpu_usage", 0.83),
+            instance.send_metric("memory_usage", 0.67),
+            instance.send_metric("disk_usage", 0.45),
+        )
+        print("Metrics sent successfully")
+
+    print(f"Instance ID: {instance.instance_id}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sync_example.py
+++ b/examples/sync_example.py
@@ -3,7 +3,7 @@
 Synchronous example of using the Replicated Python SDK.
 """
 
-from replicated import InstanceStatus, ReplicatedClient
+from replicated import ReplicatedClient
 
 
 def main():
@@ -26,14 +26,6 @@ def main():
         instance.send_metric("memory_usage", 0.67)
         instance.send_metric("disk_usage", 0.45)
         print("Metrics sent successfully")
-
-        # Set the instance status
-        instance.set_status(InstanceStatus.RUNNING)
-        print("Instance status set to RUNNING")
-
-        # Set the application version
-        instance.set_version("1.2.0")
-        print("Instance version set to 1.2.0")
 
         print("Example completed successfully!")
 

--- a/replicated/__init__.py
+++ b/replicated/__init__.py
@@ -9,7 +9,14 @@ from .exceptions import (
     ReplicatedRateLimitError,
 )
 
-__version__ = "1.0.0"
+# Try to get version from package metadata, fall back to hardcoded version
+try:
+    from importlib.metadata import version as _get_version
+
+    __version__ = _get_version("replicated") + "+python"
+except Exception:
+    # Fallback for development or if package isn't installed
+    __version__ = "1.0.0+python"
 __all__ = [
     "ReplicatedClient",
     "AsyncReplicatedClient",

--- a/replicated/async_client.py
+++ b/replicated/async_client.py
@@ -39,6 +39,8 @@ class AsyncReplicatedClient:
         # Try to use dynamic token first, fall back to publishable key
         dynamic_token = self.state_manager.get_dynamic_token()
         if dynamic_token:
-            return {"Authorization": f"Bearer {dynamic_token}"}
+            # Service tokens are sent without Bearer prefix
+            return {"Authorization": dynamic_token}
         else:
+            # Publishable keys use Bearer prefix
             return {"Authorization": f"Bearer {self.publishable_key}"}

--- a/replicated/client.py
+++ b/replicated/client.py
@@ -39,6 +39,8 @@ class ReplicatedClient:
         # Try to use dynamic token first, fall back to publishable key
         dynamic_token = self.state_manager.get_dynamic_token()
         if dynamic_token:
-            return {"Authorization": f"Bearer {dynamic_token}"}
+            # Service tokens are sent without Bearer prefix
+            return {"Authorization": dynamic_token}
         else:
+            # Publishable keys use Bearer prefix
             return {"Authorization": f"Bearer {self.publishable_key}"}

--- a/replicated/http_client.py
+++ b/replicated/http_client.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional
 
 import httpx
 
-from . import __version__
 from .exceptions import (
     ReplicatedAPIError,
     ReplicatedAuthError,
@@ -29,6 +28,9 @@ class HTTPClient:
         self, headers: Optional[Dict[str, str]] = None
     ) -> Dict[str, str]:
         """Build request headers."""
+        # Import here to avoid circular import
+        from . import __version__
+
         # Format: "Replicated-SDK/{version}" as expected by Vandoor
         user_agent = f"Replicated-SDK/{__version__}"
         request_headers = {

--- a/replicated/http_client.py
+++ b/replicated/http_client.py
@@ -51,11 +51,6 @@ class HTTPClient:
         error_message = json_body.get("message", default_msg)
         error_code = json_body.get("code")
 
-        # Debug: print the full error response
-        print(f"DEBUG: HTTP {response.status_code} Error Response:")
-        print(f"DEBUG: Response body: {response.text}")
-        print(f"DEBUG: JSON body: {json_body}")
-
         if response.status_code == 401:
             raise ReplicatedAuthError(
                 message=error_message,

--- a/replicated/http_client.py
+++ b/replicated/http_client.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 
 import httpx
 
+from . import __version__
 from .exceptions import (
     ReplicatedAPIError,
     ReplicatedAuthError,
@@ -28,9 +29,11 @@ class HTTPClient:
         self, headers: Optional[Dict[str, str]] = None
     ) -> Dict[str, str]:
         """Build request headers."""
+        # Format: "Replicated-SDK/{version}" as expected by Vandoor
+        user_agent = f"Replicated-SDK/{__version__}"
         request_headers = {
             "Content-Type": "application/json",
-            "User-Agent": "replicated-python/1.0.0",
+            "User-Agent": user_agent,
             **self.default_headers,
         }
         if headers:

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -114,7 +114,8 @@ class Instance:
                 hostname = "unknown"
 
             # Create instance tags with hostname in correct format
-            instance_tags = {"force": False, "tags": {"name": hostname}}
+            # Use force=True to override the service account name that gets set automatically
+            instance_tags = {"force": True, "tags": {"name": hostname}}
             instance_tags_b64 = base64.b64encode(
                 json.dumps(instance_tags).encode()
             ).decode()
@@ -215,7 +216,8 @@ class AsyncInstance:
                 hostname = "unknown"
 
             # Create instance tags with hostname in correct format
-            instance_tags = {"force": False, "tags": {"name": hostname}}
+            # Use force=True to override the service account name that gets set automatically
+            instance_tags = {"force": True, "tags": {"name": hostname}}
             instance_tags_b64 = base64.b64encode(
                 json.dumps(instance_tags).encode()
             ).decode()

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -89,6 +89,7 @@ class Instance:
 
         # Generate deterministic instance_id from fingerprint
         import uuid
+
         fingerprint = get_machine_fingerprint()
         # Use first 16 bytes of SHA256 hash as UUID
         instance_id = str(uuid.UUID(bytes=bytes.fromhex(fingerprint[:32])))
@@ -102,6 +103,22 @@ class Instance:
             self._ensure_instance()
 
         try:
+            import base64
+            import json
+            import socket
+
+            # Get hostname for instance tag
+            try:
+                hostname = socket.gethostname()
+            except Exception:
+                hostname = "unknown"
+
+            # Create instance tags with hostname
+            instance_tags = {"name": hostname}
+            instance_tags_b64 = base64.b64encode(
+                json.dumps(instance_tags).encode()
+            ).decode()
+
             # cluster_id is same as instance_id for non-K8s environments
             headers = {
                 **self._client._get_auth_headers(),
@@ -109,6 +126,7 @@ class Instance:
                 "X-Replicated-ClusterID": self.instance_id,
                 "X-Replicated-AppStatus": "ready",
                 "X-Replicated-ReplicatedSDKVersion": "1.0.0",
+                "X-Replicated-InstanceTagData": instance_tags_b64,
             }
 
             self._client.http_client._make_request(
@@ -167,6 +185,7 @@ class AsyncInstance:
 
         # Generate deterministic instance_id from fingerprint
         import uuid
+
         fingerprint = get_machine_fingerprint()
         # Use first 16 bytes of SHA256 hash as UUID
         instance_id = str(uuid.UUID(bytes=bytes.fromhex(fingerprint[:32])))
@@ -180,6 +199,22 @@ class AsyncInstance:
             await self._ensure_instance()
 
         try:
+            import base64
+            import json
+            import socket
+
+            # Get hostname for instance tag
+            try:
+                hostname = socket.gethostname()
+            except Exception:
+                hostname = "unknown"
+
+            # Create instance tags with hostname
+            instance_tags = {"name": hostname}
+            instance_tags_b64 = base64.b64encode(
+                json.dumps(instance_tags).encode()
+            ).decode()
+
             # cluster_id is same as instance_id for non-K8s environments
             headers = {
                 **self._client._get_auth_headers(),
@@ -187,6 +222,7 @@ class AsyncInstance:
                 "X-Replicated-ClusterID": self.instance_id,
                 "X-Replicated-AppStatus": "ready",
                 "X-Replicated-ReplicatedSDKVersion": "1.0.0",
+                "X-Replicated-InstanceTagData": instance_tags_b64,
             }
 
             await self._client.http_client._make_request_async(

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -113,8 +113,7 @@ class Instance:
             except Exception:
                 hostname = "unknown"
 
-            # Create instance tags with hostname in correct format
-            # Use force=True to override the service account name that gets set automatically
+            # Create instance tags with hostname as instance name
             instance_tags = {"force": True, "tags": {"name": hostname}}
             instance_tags_b64 = base64.b64encode(
                 json.dumps(instance_tags).encode()
@@ -210,8 +209,7 @@ class AsyncInstance:
             except Exception:
                 hostname = "unknown"
 
-            # Create instance tags with hostname in correct format
-            # Use force=True to override the service account name that gets set automatically
+            # Create instance tags with hostname as instance name
             instance_tags = {"force": True, "tags": {"name": hostname}}
             instance_tags_b64 = base64.b64encode(
                 json.dumps(instance_tags).encode()

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from .enums import InstanceStatus
 from .fingerprint import get_machine_fingerprint
 
 if TYPE_CHECKING:
@@ -68,51 +67,17 @@ class Instance:
         """Send a metric for this instance."""
         if not self.instance_id:
             self._ensure_instance()
+            self._report_instance()
 
         self._client.http_client._make_request(
             "POST",
-            f"/application/custom-metrics/{name}",
-            json_data={"name": name, "value": value},
-            headers=self._client._get_auth_headers(),
-        )
-
-    def delete_metric(self, name: str) -> None:
-        """Delete a metric for this instance."""
-        if not self.instance_id:
-            self._ensure_instance()
-
-        self._client.http_client._make_request(
-            "DELETE",
-            f"/application/custom-metrics/{name}",
-            headers=self._client._get_auth_headers(),
-        )
-
-    def set_status(self, status: InstanceStatus) -> None:
-        """Set the status of this instance."""
-        if not self.instance_id:
-            self._ensure_instance()
-
-        self._client.http_client._make_request(
-            "PATCH",
-            f"/api/v1/instances/{self.instance_id}",
-            json_data={"status": status.value},
-            headers=self._client._get_auth_headers(),
-        )
-
-    def set_version(self, version: str) -> None:
-        """Set the version of this instance."""
-        if not self.instance_id:
-            self._ensure_instance()
-
-        self._client.http_client._make_request(
-            "PATCH",
-            f"/api/v1/instances/{self.instance_id}",
-            json_data={"version": version},
+            "/application/custom-metrics",
+            json_data={"data": {name: value}},
             headers=self._client._get_auth_headers(),
         )
 
     def _ensure_instance(self) -> None:
-        """Ensure the instance exists and is cached."""
+        """Ensure the instance ID is generated and cached."""
         if self.instance_id:
             return
 
@@ -122,17 +87,35 @@ class Instance:
             self.instance_id = cached_instance_id
             return
 
-        # Create new instance
+        # Generate deterministic instance_id from fingerprint
+        import uuid
         fingerprint = get_machine_fingerprint()
-        response = self._client.http_client._make_request(
-            "POST",
-            f"/api/v1/customers/{self.customer_id}/instances",
-            json_data={"fingerprint": fingerprint},
-            headers=self._client._get_auth_headers(),
-        )
+        # Use first 16 bytes of SHA256 hash as UUID
+        instance_id = str(uuid.UUID(bytes=bytes.fromhex(fingerprint[:32])))
 
-        self.instance_id = response["id"]
-        self._client.state_manager.set_instance_id(self.instance_id)
+        self.instance_id = instance_id
+        self._client.state_manager.set_instance_id(instance_id)
+
+    def _report_instance(self) -> None:
+        """Send instance telemetry to vandoor."""
+        if not self.instance_id:
+            self._ensure_instance()
+
+        # cluster_id is same as instance_id for non-K8s environments
+        headers = {
+            **self._client._get_auth_headers(),
+            "X-Replicated-InstanceID": self.instance_id,
+            "X-Replicated-ClusterID": self.instance_id,
+            "X-Replicated-AppStatus": "ready",
+            "X-Replicated-ReplicatedSDKVersion": "1.0.0",
+        }
+
+        self._client.http_client._make_request(
+            "POST",
+            "/kots_metrics/license_instance/info",
+            headers=headers,
+            json_data={},
+        )
 
     def __getattr__(self, name: str) -> Any:
         """Access additional instance data."""
@@ -158,51 +141,17 @@ class AsyncInstance:
         """Send a metric for this instance."""
         if not self.instance_id:
             await self._ensure_instance()
+            await self._report_instance()
 
         await self._client.http_client._make_request_async(
             "POST",
-            f"/application/custom-metrics",
-            json_data={"name": name, "value": value},
-            headers=self._client._get_auth_headers(),
-        )
-
-    async def delete_metric(self, name: str) -> None:
-        """Delete a metric for this instance."""
-        if not self.instance_id:
-            await self._ensure_instance()
-
-        await self._client.http_client._make_request_async(
-            "DELETE",
-            f"/application/custom-metrics/{name}",
-            headers=self._client._get_auth_headers(),
-        )
-
-    async def set_status(self, status: InstanceStatus) -> None:
-        """Set the status of this instance."""
-        if not self.instance_id:
-            await self._ensure_instance()
-
-        await self._client.http_client._make_request_async(
-            "PATCH",
-            f"/api/v1/instances/{self.instance_id}",
-            json_data={"status": status.value},
-            headers=self._client._get_auth_headers(),
-        )
-
-    async def set_version(self, version: str) -> None:
-        """Set the version of this instance."""
-        if not self.instance_id:
-            await self._ensure_instance()
-
-        await self._client.http_client._make_request_async(
-            "PATCH",
-            f"/api/v1/instances/{self.instance_id}",
-            json_data={"version": version},
+            "/application/custom-metrics",
+            json_data={"data": {name: value}},
             headers=self._client._get_auth_headers(),
         )
 
     async def _ensure_instance(self) -> None:
-        """Ensure the instance exists and is cached."""
+        """Ensure the instance ID is generated and cached."""
         if self.instance_id:
             return
 
@@ -212,17 +161,35 @@ class AsyncInstance:
             self.instance_id = cached_instance_id
             return
 
-        # Create new instance
+        # Generate deterministic instance_id from fingerprint
+        import uuid
         fingerprint = get_machine_fingerprint()
-        response = await self._client.http_client._make_request_async(
-            "POST",
-            f"/api/v1/customers/{self.customer_id}/instances",
-            json_data={"fingerprint": fingerprint},
-            headers=self._client._get_auth_headers(),
-        )
+        # Use first 16 bytes of SHA256 hash as UUID
+        instance_id = str(uuid.UUID(bytes=bytes.fromhex(fingerprint[:32])))
 
-        self.instance_id = response["id"]
-        self._client.state_manager.set_instance_id(self.instance_id)
+        self.instance_id = instance_id
+        self._client.state_manager.set_instance_id(instance_id)
+
+    async def _report_instance(self) -> None:
+        """Send instance telemetry to vandoor."""
+        if not self.instance_id:
+            await self._ensure_instance()
+
+        # cluster_id is same as instance_id for non-K8s environments
+        headers = {
+            **self._client._get_auth_headers(),
+            "X-Replicated-InstanceID": self.instance_id,
+            "X-Replicated-ClusterID": self.instance_id,
+            "X-Replicated-AppStatus": "ready",
+            "X-Replicated-ReplicatedSDKVersion": "1.0.0",
+        }
+
+        await self._client.http_client._make_request_async(
+            "POST",
+            "/kots_metrics/license_instance/info",
+            headers=headers,
+            json_data={},
+        )
 
     def __getattr__(self, name: str) -> Any:
         """Access additional instance data."""

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -31,10 +31,10 @@ class Customer:
         """Get or create an instance for this customer."""
         if hasattr(self._client, "_get_or_create_instance_async"):
             # type: ignore[arg-type]
-            return AsyncInstance(self._client, self.customer_id)
+            return AsyncInstance(self._client, self.customer_id, self.instance_id)
         else:
             # type: ignore[arg-type]
-            return Instance(self._client, self.customer_id)
+            return Instance(self._client, self.customer_id, self.instance_id)
 
     def __getattr__(self, name: str) -> Any:
         """Access additional customer data."""
@@ -48,7 +48,7 @@ class AsyncCustomer(Customer):
     async def get_or_create_instance(self) -> "AsyncInstance":
         """Get or create an instance for this customer."""
         # type: ignore[arg-type]
-        return AsyncInstance(self._client, self.customer_id)
+        return AsyncInstance(self._client, self.customer_id, self.instance_id)
 
 
 class Instance:
@@ -72,7 +72,6 @@ class Instance:
         """Send a metric for this instance."""
         if not self.instance_id:
             self._ensure_instance()
-            self._report_instance()
 
         # Merge metric with existing metrics (overwrite = false behavior)
         self._metrics[name] = value
@@ -115,12 +114,15 @@ class Instance:
         fingerprint = get_machine_fingerprint()
         response = self._client.http_client._make_request(
             "POST",
-            f"/api/v1/customers/{self.customer_id}/instances",
-            json_data={"fingerprint": fingerprint},
+            "/v3/instance",
+            json_data={
+                "machine_fingerprint": fingerprint,
+                "app_status": "missing",
+            },
             headers=self._client._get_auth_headers(),
         )
 
-        self.instance_id = response["id"]
+        self.instance_id = response["instance_id"]
         self._client.state_manager.set_instance_id(self.instance_id)
 
     def _report_instance(self) -> None:
@@ -191,7 +193,6 @@ class AsyncInstance:
         """Send a metric for this instance."""
         if not self.instance_id:
             await self._ensure_instance()
-            await self._report_instance()
 
         # Merge metric with existing metrics (overwrite = false behavior)
         self._metrics[name] = value
@@ -213,6 +214,9 @@ class AsyncInstance:
 
     async def set_status(self, status: str) -> None:
         """Set the status of this instance for telemetry reporting."""
+        if not self.instance_id:
+            await self._ensure_instance()
+
         self._status = status
         await self._report_instance()
 
@@ -227,15 +231,20 @@ class AsyncInstance:
             self.instance_id = cached_instance_id
             return
 
-        # Generate deterministic instance_id from fingerprint
-        import uuid
-
+        # Create new instance
         fingerprint = get_machine_fingerprint()
-        # Use first 16 bytes of SHA256 hash as UUID
-        instance_id = str(uuid.UUID(bytes=bytes.fromhex(fingerprint[:32])))
+        response = await self._client.http_client._make_request_async(
+            "POST",
+            "/v3/instance",
+            json_data={
+                "machine_fingerprint": fingerprint,
+                "app_status": "missing",
+            },
+            headers=self._client._get_auth_headers(),
+        )
 
-        self.instance_id = instance_id
-        self._client.state_manager.set_instance_id(instance_id)
+        self.instance_id = response["instance_id"]
+        self._client.state_manager.set_instance_id(self.instance_id)
 
     async def _report_instance(self) -> None:
         """Send instance telemetry to vandoor."""

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -113,8 +113,8 @@ class Instance:
             except Exception:
                 hostname = "unknown"
 
-            # Create instance tags with hostname
-            instance_tags = {"name": hostname}
+            # Create instance tags with hostname in correct format
+            instance_tags = {"force": False, "tags": {"name": hostname}}
             instance_tags_b64 = base64.b64encode(
                 json.dumps(instance_tags).encode()
             ).decode()
@@ -129,14 +129,19 @@ class Instance:
                 "X-Replicated-InstanceTagData": instance_tags_b64,
             }
 
+            print(f"DEBUG: Sending telemetry with hostname tag: {hostname}")
+            print(f"DEBUG: Instance tags (base64): {instance_tags_b64}")
+
             self._client.http_client._make_request(
                 "POST",
                 "/kots_metrics/license_instance/info",
                 headers=headers,
                 json_data={},
             )
-        except Exception:
+            print("DEBUG: Telemetry sent successfully")
+        except Exception as e:
             # Telemetry is optional - don't fail if it doesn't work
+            print(f"DEBUG: Telemetry failed: {e}")
             pass
 
     def __getattr__(self, name: str) -> Any:
@@ -209,8 +214,8 @@ class AsyncInstance:
             except Exception:
                 hostname = "unknown"
 
-            # Create instance tags with hostname
-            instance_tags = {"name": hostname}
+            # Create instance tags with hostname in correct format
+            instance_tags = {"force": False, "tags": {"name": hostname}}
             instance_tags_b64 = base64.b64encode(
                 json.dumps(instance_tags).encode()
             ).decode()
@@ -225,14 +230,19 @@ class AsyncInstance:
                 "X-Replicated-InstanceTagData": instance_tags_b64,
             }
 
+            print(f"DEBUG: Sending telemetry with hostname tag: {hostname}")
+            print(f"DEBUG: Instance tags (base64): {instance_tags_b64}")
+
             await self._client.http_client._make_request_async(
                 "POST",
                 "/kots_metrics/license_instance/info",
                 headers=headers,
                 json_data={},
             )
-        except Exception:
+            print("DEBUG: Telemetry sent successfully")
+        except Exception as e:
             # Telemetry is optional - don't fail if it doesn't work
+            print(f"DEBUG: Telemetry failed: {e}")
             pass
 
     def __getattr__(self, name: str) -> Any:

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -184,7 +184,7 @@ class AsyncInstance:
             headers=self._client._get_auth_headers(),
         )
 
-    def set_status(self, status: str) -> None:
+    async def set_status(self, status: str) -> None:
         """Set the status of this instance for telemetry reporting."""
         self._status = status
         await self._report_instance()

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -71,7 +71,7 @@ class Instance:
 
         self._client.http_client._make_request(
             "POST",
-            f"/v1/instances/{self.instance_id}/metrics",
+            f"/application/custom-metrics/{name}",
             json_data={"name": name, "value": value},
             headers=self._client._get_auth_headers(),
         )

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -66,6 +66,7 @@ class Instance:
         self.instance_id = instance_id
         self._data = kwargs
         self._status = "ready"
+        self._metrics: dict[str, Union[int, float, str]] = {}
 
     def send_metric(self, name: str, value: Union[int, float, str]) -> None:
         """Send a metric for this instance."""
@@ -73,11 +74,22 @@ class Instance:
             self._ensure_instance()
             self._report_instance()
 
+        # Merge metric with existing metrics (overwrite = false behavior)
+        self._metrics[name] = value
+
+        # Build headers with instance data
+        headers = {
+            **self._client._get_auth_headers(),
+            "X-Replicated-InstanceID": self.instance_id,
+            "X-Replicated-ClusterID": self.instance_id,
+            "X-Replicated-AppStatus": self._status,
+        }
+
         self._client.http_client._make_request(
             "POST",
             "/application/custom-metrics",
-            json_data={"data": {name: value}},
-            headers=self._client._get_auth_headers(),
+            json_data={"data": self._metrics},
+            headers=headers,
         )
 
     def set_status(self, status: str) -> None:
@@ -173,6 +185,7 @@ class AsyncInstance:
         self.instance_id = instance_id
         self._data = kwargs
         self._status = "ready"
+        self._metrics: dict[str, Union[int, float, str]] = {}
 
     async def send_metric(self, name: str, value: Union[int, float, str]) -> None:
         """Send a metric for this instance."""
@@ -180,11 +193,22 @@ class AsyncInstance:
             await self._ensure_instance()
             await self._report_instance()
 
+        # Merge metric with existing metrics (overwrite = false behavior)
+        self._metrics[name] = value
+
+        # Build headers with instance data
+        headers = {
+            **self._client._get_auth_headers(),
+            "X-Replicated-InstanceID": self.instance_id,
+            "X-Replicated-ClusterID": self.instance_id,
+            "X-Replicated-AppStatus": self._status,
+        }
+
         await self._client.http_client._make_request_async(
             "POST",
             "/application/custom-metrics",
-            json_data={"data": {name: value}},
-            headers=self._client._get_auth_headers(),
+            json_data={"data": self._metrics},
+            headers=headers,
         )
 
     async def set_status(self, status: str) -> None:

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -71,7 +71,7 @@ class Instance:
 
         self._client.http_client._make_request(
             "POST",
-            f"/api/v1/instances/{self.instance_id}/metrics",
+            f"/v1/instances/{self.instance_id}/metrics",
             json_data={"name": name, "value": value},
             headers=self._client._get_auth_headers(),
         )
@@ -83,7 +83,7 @@ class Instance:
 
         self._client.http_client._make_request(
             "DELETE",
-            f"/api/v1/instances/{self.instance_id}/metrics/{name}",
+            f"/application/custom-metrics/{name}",
             headers=self._client._get_auth_headers(),
         )
 
@@ -161,7 +161,7 @@ class AsyncInstance:
 
         await self._client.http_client._make_request_async(
             "POST",
-            f"/api/v1/instances/{self.instance_id}/metrics",
+            f"/application/custom-metrics",
             json_data={"name": name, "value": value},
             headers=self._client._get_auth_headers(),
         )
@@ -173,7 +173,7 @@ class AsyncInstance:
 
         await self._client.http_client._make_request_async(
             "DELETE",
-            f"/api/v1/instances/{self.instance_id}/metrics/{name}",
+            f"/application/custom-metrics/{name}",
             headers=self._client._get_auth_headers(),
         )
 

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -130,19 +130,14 @@ class Instance:
                 "X-Replicated-InstanceTagData": instance_tags_b64,
             }
 
-            print(f"DEBUG: Sending telemetry with hostname tag: {hostname}")
-            print(f"DEBUG: Instance tags (base64): {instance_tags_b64}")
-
             self._client.http_client._make_request(
                 "POST",
                 "/kots_metrics/license_instance/info",
                 headers=headers,
                 json_data={},
             )
-            print("DEBUG: Telemetry sent successfully")
-        except Exception as e:
+        except Exception:
             # Telemetry is optional - don't fail if it doesn't work
-            print(f"DEBUG: Telemetry failed: {e}")
             pass
 
     def __getattr__(self, name: str) -> Any:
@@ -232,19 +227,14 @@ class AsyncInstance:
                 "X-Replicated-InstanceTagData": instance_tags_b64,
             }
 
-            print(f"DEBUG: Sending telemetry with hostname tag: {hostname}")
-            print(f"DEBUG: Instance tags (base64): {instance_tags_b64}")
-
             await self._client.http_client._make_request_async(
                 "POST",
                 "/kots_metrics/license_instance/info",
                 headers=headers,
                 json_data={},
             )
-            print("DEBUG: Telemetry sent successfully")
-        except Exception as e:
+        except Exception:
             # Telemetry is optional - don't fail if it doesn't work
-            print(f"DEBUG: Telemetry failed: {e}")
             pass
 
     def __getattr__(self, name: str) -> Any:

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -101,21 +101,25 @@ class Instance:
         if not self.instance_id:
             self._ensure_instance()
 
-        # cluster_id is same as instance_id for non-K8s environments
-        headers = {
-            **self._client._get_auth_headers(),
-            "X-Replicated-InstanceID": self.instance_id,
-            "X-Replicated-ClusterID": self.instance_id,
-            "X-Replicated-AppStatus": "ready",
-            "X-Replicated-ReplicatedSDKVersion": "1.0.0",
-        }
+        try:
+            # cluster_id is same as instance_id for non-K8s environments
+            headers = {
+                **self._client._get_auth_headers(),
+                "X-Replicated-InstanceID": self.instance_id,
+                "X-Replicated-ClusterID": self.instance_id,
+                "X-Replicated-AppStatus": "ready",
+                "X-Replicated-ReplicatedSDKVersion": "1.0.0",
+            }
 
-        self._client.http_client._make_request(
-            "POST",
-            "/kots_metrics/license_instance/info",
-            headers=headers,
-            json_data={},
-        )
+            self._client.http_client._make_request(
+                "POST",
+                "/kots_metrics/license_instance/info",
+                headers=headers,
+                json_data={},
+            )
+        except Exception:
+            # Telemetry is optional - don't fail if it doesn't work
+            pass
 
     def __getattr__(self, name: str) -> Any:
         """Access additional instance data."""
@@ -175,21 +179,25 @@ class AsyncInstance:
         if not self.instance_id:
             await self._ensure_instance()
 
-        # cluster_id is same as instance_id for non-K8s environments
-        headers = {
-            **self._client._get_auth_headers(),
-            "X-Replicated-InstanceID": self.instance_id,
-            "X-Replicated-ClusterID": self.instance_id,
-            "X-Replicated-AppStatus": "ready",
-            "X-Replicated-ReplicatedSDKVersion": "1.0.0",
-        }
+        try:
+            # cluster_id is same as instance_id for non-K8s environments
+            headers = {
+                **self._client._get_auth_headers(),
+                "X-Replicated-InstanceID": self.instance_id,
+                "X-Replicated-ClusterID": self.instance_id,
+                "X-Replicated-AppStatus": "ready",
+                "X-Replicated-ReplicatedSDKVersion": "1.0.0",
+            }
 
-        await self._client.http_client._make_request_async(
-            "POST",
-            "/kots_metrics/license_instance/info",
-            headers=headers,
-            json_data={},
-        )
+            await self._client.http_client._make_request_async(
+                "POST",
+                "/kots_metrics/license_instance/info",
+                headers=headers,
+                json_data={},
+            )
+        except Exception:
+            # Telemetry is optional - don't fail if it doesn't work
+            pass
 
     def __getattr__(self, name: str) -> Any:
         """Access additional instance data."""

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -84,6 +84,7 @@ class Instance:
         """Set the status of this instance for telemetry reporting."""
         if not self.instance_id:
             self._ensure_instance()
+
         self._status = status
         self._report_instance()
 
@@ -98,15 +99,17 @@ class Instance:
             self.instance_id = cached_instance_id
             return
 
-        # Generate deterministic instance_id from fingerprint
-        import uuid
-
+        # Create new instance
         fingerprint = get_machine_fingerprint()
-        # Use first 16 bytes of SHA256 hash as UUID
-        instance_id = str(uuid.UUID(bytes=bytes.fromhex(fingerprint[:32])))
+        response = self._client.http_client._make_request(
+            "POST",
+            f"/api/v1/customers/{self.customer_id}/instances",
+            json_data={"fingerprint": fingerprint},
+            headers=self._client._get_auth_headers(),
+        )
 
-        self.instance_id = instance_id
-        self._client.state_manager.set_instance_id(instance_id)
+        self.instance_id = response["id"]
+        self._client.state_manager.set_instance_id(self.instance_id)
 
     def _report_instance(self) -> None:
         """Send instance telemetry to vandoor."""

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -1,6 +1,9 @@
+import logging
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from .fingerprint import get_machine_fingerprint
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .async_client import AsyncReplicatedClient
@@ -110,7 +113,8 @@ class Instance:
             # Get hostname for instance tag
             try:
                 hostname = socket.gethostname()
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Failed to get hostname: {e}")
                 hostname = "unknown"
 
             # Create instance tags with hostname as instance name
@@ -135,9 +139,9 @@ class Instance:
                 headers=headers,
                 json_data={},
             )
-        except Exception:
+        except Exception as e:
             # Telemetry is optional - don't fail if it doesn't work
-            pass
+            logger.debug(f"Failed to report instance telemetry: {e}")
 
     def __getattr__(self, name: str) -> Any:
         """Access additional instance data."""
@@ -206,7 +210,8 @@ class AsyncInstance:
             # Get hostname for instance tag
             try:
                 hostname = socket.gethostname()
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Failed to get hostname: {e}")
                 hostname = "unknown"
 
             # Create instance tags with hostname as instance name
@@ -231,9 +236,9 @@ class AsyncInstance:
                 headers=headers,
                 json_data={},
             )
-        except Exception:
+        except Exception as e:
             # Telemetry is optional - don't fail if it doesn't work
-            pass
+            logger.debug(f"Failed to report instance telemetry: {e}")
 
     def __getattr__(self, name: str) -> Any:
         """Access additional instance data."""

--- a/replicated/resources.py
+++ b/replicated/resources.py
@@ -65,6 +65,7 @@ class Instance:
         self.customer_id = customer_id
         self.instance_id = instance_id
         self._data = kwargs
+        self._status = "ready"
 
     def send_metric(self, name: str, value: Union[int, float, str]) -> None:
         """Send a metric for this instance."""
@@ -78,6 +79,13 @@ class Instance:
             json_data={"data": {name: value}},
             headers=self._client._get_auth_headers(),
         )
+
+    def set_status(self, status: str) -> None:
+        """Set the status of this instance for telemetry reporting."""
+        if not self.instance_id:
+            self._ensure_instance()
+        self._status = status
+        self._report_instance()
 
     def _ensure_instance(self) -> None:
         """Ensure the instance ID is generated and cached."""
@@ -128,8 +136,7 @@ class Instance:
                 **self._client._get_auth_headers(),
                 "X-Replicated-InstanceID": self.instance_id,
                 "X-Replicated-ClusterID": self.instance_id,
-                "X-Replicated-AppStatus": "ready",
-                "X-Replicated-ReplicatedSDKVersion": "1.0.0",
+                "X-Replicated-AppStatus": self._status,
                 "X-Replicated-InstanceTagData": instance_tags_b64,
             }
 
@@ -162,6 +169,7 @@ class AsyncInstance:
         self.customer_id = customer_id
         self.instance_id = instance_id
         self._data = kwargs
+        self._status = "ready"
 
     async def send_metric(self, name: str, value: Union[int, float, str]) -> None:
         """Send a metric for this instance."""
@@ -175,6 +183,11 @@ class AsyncInstance:
             json_data={"data": {name: value}},
             headers=self._client._get_auth_headers(),
         )
+
+    def set_status(self, status: str) -> None:
+        """Set the status of this instance for telemetry reporting."""
+        self._status = status
+        await self._report_instance()
 
     async def _ensure_instance(self) -> None:
         """Ensure the instance ID is generated and cached."""
@@ -225,8 +238,7 @@ class AsyncInstance:
                 **self._client._get_auth_headers(),
                 "X-Replicated-InstanceID": self.instance_id,
                 "X-Replicated-ClusterID": self.instance_id,
-                "X-Replicated-AppStatus": "ready",
-                "X-Replicated-ReplicatedSDKVersion": "1.0.0",
+                "X-Replicated-AppStatus": self._status,
                 "X-Replicated-InstanceTagData": instance_tags_b64,
             }
 

--- a/replicated/services.py
+++ b/replicated/services.py
@@ -25,10 +25,6 @@ class CustomerService:
         cached_email = self._client.state_manager.get_customer_email()
 
         if cached_customer_id and cached_email == email_address:
-            print(
-                f"DEBUG: Using cached customer ID {cached_customer_id} "
-                f"for email {email_address}"
-            )
             return Customer(
                 self._client,
                 cached_customer_id,
@@ -36,10 +32,6 @@ class CustomerService:
                 channel,
             )
         elif cached_customer_id and cached_email != email_address:
-            print(
-                f"DEBUG: Email changed from {cached_email} to "
-                f"{email_address}, clearing cache"
-            )
             self._client.state_manager.clear_state()
 
         # Create or fetch customer
@@ -55,7 +47,6 @@ class CustomerService:
             headers=self._client._get_auth_headers(),
         )
 
-        print(f"DEBUG: API Response: {response}")
         customer_id = response["customer"]["id"]
         self._client.state_manager.set_customer_id(customer_id)
         self._client.state_manager.set_customer_email(email_address)
@@ -67,7 +58,6 @@ class CustomerService:
         elif "customer" in response and "serviceToken" in response["customer"]:
             service_token = response["customer"]["serviceToken"]
             self._client.state_manager.set_dynamic_token(service_token)
-            print(f"DEBUG: Stored service token: {service_token[:20]}...")
 
         response_data = response.copy()
         response_data.pop("email_address", None)
@@ -110,10 +100,6 @@ class AsyncCustomerService:
                 channel,
             )
         elif cached_customer_id and cached_email != email_address:
-            print(
-                f"DEBUG: Email changed from {cached_email} to "
-                f"{email_address}, clearing cache"
-            )
             self._client.state_manager.clear_state()
 
         # Create or fetch customer
@@ -129,7 +115,6 @@ class AsyncCustomerService:
             headers=self._client._get_auth_headers(),
         )
 
-        print(f"DEBUG: API Response: {response}")
         customer_id = response["customer"]["id"]
         self._client.state_manager.set_customer_id(customer_id)
         self._client.state_manager.set_customer_email(email_address)
@@ -141,7 +126,6 @@ class AsyncCustomerService:
         elif "customer" in response and "serviceToken" in response["customer"]:
             service_token = response["customer"]["serviceToken"]
             self._client.state_manager.set_dynamic_token(service_token)
-            print(f"DEBUG: Stored service token: {service_token[:20]}...")
 
         response_data = response.copy()
         response_data.pop("email_address", None)

--- a/replicated/services.py
+++ b/replicated/services.py
@@ -89,10 +89,6 @@ class AsyncCustomerService:
         cached_email = self._client.state_manager.get_customer_email()
 
         if cached_customer_id and cached_email == email_address:
-            print(
-                f"DEBUG: Using cached customer ID {cached_customer_id} "
-                f"for email {email_address}"
-            )
             return AsyncCustomer(
                 self._client,
                 cached_customer_id,

--- a/replicated/services.py
+++ b/replicated/services.py
@@ -48,8 +48,10 @@ class CustomerService:
         )
 
         customer_id = response["customer"]["id"]
+        instance_id = response["customer"]["instanceId"]
         self._client.state_manager.set_customer_id(customer_id)
         self._client.state_manager.set_customer_email(email_address)
+        self._client.state_manager.set_instance_id(instance_id)
 
         # Store dynamic token if provided
         if "dynamic_token" in response:
@@ -112,8 +114,10 @@ class AsyncCustomerService:
         )
 
         customer_id = response["customer"]["id"]
+        instance_id = response["customer"]["instanceId"]
         self._client.state_manager.set_customer_id(customer_id)
         self._client.state_manager.set_customer_email(email_address)
+        self._client.state_manager.set_instance_id(instance_id)
 
         # Store dynamic token if provided
         if "dynamic_token" in response:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,6 +27,8 @@ class TestReplicatedClient:
                 "id": "customer_123",
                 "email": "test@example.com",
                 "name": "test user",
+                "serviceToken": "service_token_123",
+                "instanceId": "instance_123",
             }
         }
 


### PR DESCRIPTION
TL;DR
-----

Aligns Python SDK with available or soon to be deployed endpoints

Details
--------

The Python SDK previously called several endpoints that don't exist in Vandoor, causing instance tracking and metrics reporting to fail. This change either 

This change adopts the telemetry-based architecture used by the Go SDK. Instance metadata flows through telemetry headers to `/kots_metrics/license_instance/info` rather than explicit CRUD operations.

Authentication now correctly distinguishes between publishable keys (which use Bearer prefix) and service tokens (raw token without prefix), matching Vandoor's middleware expectations. Custom metrics use the proper format with `{"data": {name: value}}` structure and correct `/application/custom-metrics` endpoint.

Co-Authored-By: @jpshackelford
Co-Authored-By: Open Hands <noreply@all-hands.dev>
Co-Authored-by:  Claude Code <noreply@anthropic.com>
